### PR TITLE
gitlab 9.5.0 dropped "reopened" status

### DIFF
--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -35,7 +35,7 @@ TICKET_STATE_TO_ISSUE_STATE = {
     'new': 'opened',
     'assigned': 'opened',
     'accepted': 'opened',
-    'reopened': 'reopened',
+    'reopened': 'opened',
     'closed': 'closed',
 }
 


### PR DESCRIPTION
https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/12972

without the patch i was getting such errors when using export/import feature:

```
Error importing repository into glen/p4
- Failed to replace issues because one or more of the new records could not be saved.
State is invalid
```