### PR TITLE
bulk changes to improve importing quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ target/
 
 # Development virtualenv
 .venv/
+/VENV

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# vim
+*~
+*.sw[op]
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/convert.sh
+++ b/convert.sh
@@ -1,13 +1,7 @@
 #!/bin/sh
 set -xe
 
-if [ ! -d VENV ]; then
-	virtualenv -p python2.7 VENV
-	. VENV/bin/activate
-	pip install -r requirements/dist.txt
-	pip install -e .
-	chmod -R a+rX .
-fi
+./env.sh
 
 set +e
 ./tracboat.sh -vv --config-file="$@" migrate >out.log 2>error.log

--- a/convert.sh
+++ b/convert.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
-set -x
+set -xe
+
+if [ ! -d VENV ]; then
+	virtualenv -p python2.7 VENV
+	. VENV/bin/activate
+	pip install -r requirements/dist.txt
+	pip install -e .
+	chmod -R a+rX .
+fi
 
 ./tracboat.sh -vv --config-file="$@" migrate >out.log 2>error.log || tail error.log 

--- a/convert.sh
+++ b/convert.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -x
+
+./tracboat.sh -vv --config-file="$@" migrate >out.log 2>error.log || tail error.log 

--- a/convert.sh
+++ b/convert.sh
@@ -9,4 +9,6 @@ if [ ! -d VENV ]; then
 	chmod -R a+rX .
 fi
 
-./tracboat.sh -vv --config-file="$@" migrate >out.log 2>error.log || tail error.log 
+set +e
+./tracboat.sh -vv --config-file="$@" migrate >out.log 2>error.log
+tail error.log

--- a/dump-shelve.py
+++ b/dump-shelve.py
@@ -2,8 +2,10 @@
 
 import shelve
 import sys
-from pprint import pprint
 
 filename = sys.argv[1]
 db = shelve.open(filename)
-pprint(db)
+for k,v in db.iteritems():
+    print "'%s' => '%s'" % (k, v)
+
+db.close()

--- a/dump-shelve.py
+++ b/dump-shelve.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python2
+
+import shelve
+import sys
+from pprint import pprint
+
+filename = sys.argv[1]
+db = shelve.open(filename)
+pprint(db)

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -xe
+set -e
 
 if [ ! -d VENV ]; then
 	virtualenv -p python2.7 VENV

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -xe
+
+if [ ! -d VENV ]; then
+	virtualenv -p python2.7 VENV
+	. VENV/bin/activate
+	pip install -r requirements/dist.txt
+	pip install -e .
+	chmod -R a+rX .
+fi
+

--- a/model-generate.sh
+++ b/model-generate.sh
@@ -9,6 +9,31 @@ ver=$(echo "$version" | cut -d. -f1,2 | tr -d .)
 
 model=src/tracboat/gitlab/model/model$ver.py
 sudo -H -u git VENV/bin/pwiz.py -u gitlab --engine=postgresql --host=/var/opt/gitlab/postgresql gitlabhq_production > $model
+
+patch -R $model <<EOF
+--- src/tracboat/gitlab/model/model104.py	2018-01-02 20:52:44.144989068 +0200
++++ src/tracboat/gitlab/model/model104.py	2018-02-07 13:29:43.314348521 +0200
+@@ -1,15 +1,13 @@
+-# -*- coding: utf-8 -*-
+-
+ from peewee import *
+ 
+-database_proxy = Proxy()
++database = PostgresqlDatabase('gitlabhq_production', **{'host': '/var/opt/gitlab/postgresql', 'user': 'gitlab'})
+ 
+ class UnknownField(object):
+-    pass
++    def __init__(self, *_, **__): pass
+ 
+ class BaseModel(Model):
+     class Meta:
+-        database = database_proxy
++        database = database
+ 
+ class AbuseReports(BaseModel):
+     cached_markdown_version = IntegerField(null=True)
+EOF
+
 chmod a+r $model
 git add $model
 git commit -m "add model for $version" $model

--- a/model-generate.sh
+++ b/model-generate.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -xe
+
+./env.sh
+
+package='gitlab-ce'
+version=$(dpkg-query -f '${Version}\n' -W "$package")
+ver=$(echo "$version" | cut -d. -f1,2 | tr -d .)
+
+model=src/tracboat/gitlab/model/model$ver.py
+sudo -H -u git VENV/bin/pwiz.py -u gitlab --engine=postgresql --host=/var/opt/gitlab/postgresql gitlabhq_production > $model
+chmod a+r $model
+git add $model
+git commit -m "add model for $version" $model

--- a/src/tracboat/cli.py
+++ b/src/tracboat/cli.py
@@ -394,13 +394,13 @@ def migrate(ctx, umap, umap_file, fallback_user, trac_uri, ssl_verify,
         db_connector = peewee.PostgresqlDatabase(gitlab_db_name, user=gitlab_db_user,
                                                  password=gitlab_db_password, host=gitlab_db_path)
     # 3. Migrate
-    LOG.debug('Trac: %s', _sanitize_url(trac_uri))
-    LOG.debug('GitLab project: %s', gitlab_project_name)
-    LOG.debug('GitLab version: %s', gitlab_version)
-    LOG.debug('GitLab db path: %s', gitlab_db_path)
-    LOG.debug('GitLab db name: %s', gitlab_db_name)
-    LOG.debug('GitLab uploads: %s', gitlab_uploads_path)
-    LOG.debug('GitLab fallback user: %s', fallback_user)
+    LOG.info('Trac: %s', _sanitize_url(trac_uri))
+    LOG.info('GitLab project: %s', gitlab_project_name)
+    LOG.info('GitLab version: %s', gitlab_version)
+    LOG.info('GitLab db path: %s', gitlab_db_path)
+    LOG.info('GitLab db name: %s', gitlab_db_name)
+    LOG.info('GitLab uploads: %s', gitlab_uploads_path)
+    LOG.info('GitLab fallback user: %s', fallback_user)
     trac_migrate.migrate(
         trac=project,
         gitlab_project_name=gitlab_project_name,

--- a/src/tracboat/cli.py
+++ b/src/tracboat/cli.py
@@ -344,6 +344,7 @@ def migrate(ctx, umap, umap_file, fallback_user, trac_uri, ssl_verify,
     # Crawl files in increasing priority (the latter overrides)
     usermap = {}
     userattrs = {}
+    svn2git_revisions = {}
     for filename in ufiles:
         conf = toml.load(filename)
         if 'tracboat' in conf:
@@ -353,6 +354,9 @@ def migrate(ctx, umap, umap_file, fallback_user, trac_uri, ssl_verify,
             if 'users' in conf['tracboat']:
                 LOG.info('updating user attributes with info from %r', filename)
                 userattrs.update(conf['tracboat']['users'])
+            if 'svn2git_revisions' in conf['tracboat']:
+                import shelve
+                svn2git_revisions = shelve.open(conf['tracboat']['svn2git_revisions'], 'r')
     # Add extra mappings from command line '--umap' args
     usermap.update({m[0]: m[1] for m in umap if m and m[0] and m[1]})
     # Look for default user attributes
@@ -411,6 +415,7 @@ def migrate(ctx, umap, umap_file, fallback_user, trac_uri, ssl_verify,
         gitlab_fallback_user=fallback_user,
         usermap=usermap,
         userattrs=userattrs,
+        svn2git_revisions=svn2git_revisions,
     )
     LOG.info('migration done.')
 

--- a/src/tracboat/gitlab/__init__.py
+++ b/src/tracboat/gitlab/__init__.py
@@ -84,6 +84,10 @@ class ConnectionBase(object):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def close_milestone(self, milestone_id):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def create_issue(self, **kwargs):
         raise NotImplementedError()
 

--- a/src/tracboat/gitlab/__init__.py
+++ b/src/tracboat/gitlab/__init__.py
@@ -76,6 +76,10 @@ class ConnectionBase(object):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def get_user(self, username):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def get_user_id(self, username):
         raise NotImplementedError()
 

--- a/src/tracboat/gitlab/__init__.py
+++ b/src/tracboat/gitlab/__init__.py
@@ -96,5 +96,5 @@ class ConnectionBase(object):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def save_wiki_attachment(self, outpath, binary):
+    def save_attachment(self, outpath, binary):
         raise NotImplementedError()

--- a/src/tracboat/gitlab/__init__.py
+++ b/src/tracboat/gitlab/__init__.py
@@ -24,6 +24,8 @@ class ConnectionBase(object):
         if not project:
             raise ValueError('invalid project name: {!r}'.format(project_name))
         p_name, p_groups = get_project_components(project_name)
+
+
         # TODO support for subgroups
         # In the meantime we are just creating a group joining all components
         # in a single identifier
@@ -48,13 +50,13 @@ class ConnectionBase(object):
     def project_id(self):
         if not hasattr(self, '_project_id'):
             # pylint: disable=attribute-defined-outside-init
-            self._project_id = self._get_project_id(self.project_name)
+            self._project_id = self._get_project_id()
         return self._project_id
 
     # Protected
 
     @abc.abstractmethod
-    def _get_project_id(self, project_name):
+    def _get_project_id(self):
         raise NotImplementedError()
 
     # Public API

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -149,7 +149,8 @@ class Connection(ConnectionBase):
             issue.delete_instance()
 
         # attachments from note comments and wiki
-        directory = os.path.join(self.uploads_path, 'migrated')
+        directory = os.path.join(self.uploads_path, self.project_qualname, 'migrated')
+        LOG.info("rm -rf %r" % directory)
         shutil.rmtree(directory, ignore_errors=True)
 
         # XXX: method is called "Clear issues" but clears milestones?!?!

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -79,6 +79,7 @@ class Connection(ConnectionBase):
         self.model.Labels.create_table(fail_silently=True)
         self.model.Users.create_table(fail_silently=True)
         self.model.Issues.create_table(fail_silently=True)
+        self.model.IssueAssignees.create_table(fail_silently=True)
         self.model.LabelLinks.create_table(fail_silently=True)
         self.model.Notes.create_table(fail_silently=True)
         if create_missing and not self._get_project(self.project_name, self.project_namespace):
@@ -259,6 +260,11 @@ class Connection(ConnectionBase):
             updated_at=issue.created_at
         )
         event.save()
+
+        # save issue assignee
+        # need to use .raw, because primary_key = False
+        M.IssueAssignees.raw("insert into issue_assignees (issue_id, user_id) values (%s, %s)", issue.id, issue.assignee).execute()
+
         # 3. Labels
         # TODO move label creation in a separate method
         for title in issue.labels.split(','):

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import logging
+import glob
 from datetime import datetime
 
 from . import ConnectionBase
@@ -148,10 +149,10 @@ class Connection(ConnectionBase):
                                     (M.Events.target == issue.id)).execute()
             issue.delete_instance()
 
-        # attachments from note comments and wiki
-        directory = os.path.join(self.uploads_path, self.project_qualname, 'migrated')
-        LOG.info("rm -rf %r" % directory)
-        shutil.rmtree(directory, ignore_errors=True)
+        # attachments from issue comments
+        for directory in glob.glob(os.path.join(self.uploads_path, self.project_qualname, 'issue_*')):
+            LOG.info("rm -rf %r" % directory)
+            shutil.rmtree(directory, ignore_errors=True)
 
         # XXX: method is called "Clear issues" but clears milestones?!?!
         M.Milestones.delete().where(

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -304,6 +304,17 @@ class Connection(ConnectionBase):
             )
             label_link.save()
 
+        # 4. timetracking
+        if kwargs['time_spent']:
+            M.Timelogs.create(
+                created_at=issue.created_at,
+                issue=issue.id,
+#                spent_at=None,
+                time_spent=kwargs['time_spent'],
+                updated_at=issue.created_at,
+                user=issue.author
+            ).save()
+
         return issue.id
 
     def comment_issue(self, issue_id=None, binary_attachment=None, **kwargs):

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -276,6 +276,7 @@ class Connection(ConnectionBase):
                     title=title,
                     color='#0000FF',
                     project=issue.project,
+                    description_html='Label from Trac import',
                     type='ProjectLabel',
                     created_at=issue.created_at,
                     update_at=issue.created_at

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -226,6 +226,12 @@ class Connection(ConnectionBase):
             LOG.info("MILESTONE created: %r" % milestone)
         return milestone.id
 
+    def close_milestone(self, milestone_id):
+        M = self.model
+        milestone = M.Milestones.get(M.Milestones.id == milestone_id)
+        milestone.state = 'closed'
+        milestone.save()
+
     def create_issue(self, **kwargs):
         M = self.model
         # 1. Issue

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -175,9 +175,12 @@ class Connection(ConnectionBase):
         milestone = self.get_milestone(milestone_name)
         return milestone["id"] if milestone else None
 
-    def get_user_id(self, email):
+    def get_user(self, email):
         M = self.model
-        return M.Users.get(M.Users.email == email).id
+        return M.Users.get(M.Users.email == email)
+
+    def get_user_id(self, email):
+        return self.get_user(email).id
 
     # def get_issues_iid(self):
     #     M = self.model

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -3,7 +3,6 @@
 import os
 import shutil
 import logging
-import codecs
 from datetime import datetime
 
 from . import ConnectionBase
@@ -148,6 +147,10 @@ class Connection(ConnectionBase):
                                     (M.Events.target_type == 'Issue') &
                                     (M.Events.target == issue.id)).execute()
             issue.delete_instance()
+
+        # attachments from note comments and wiki
+        directory = os.path.join(self.uploads_path, 'migrated')
+        shutil.rmtree(directory, ignore_errors=True)
 
         # XXX: method is called "Clear issues" but clears milestones?!?!
         M.Milestones.delete().where(
@@ -309,12 +312,12 @@ class Connection(ConnectionBase):
                 bin_f.write(binary_attachment)
         return note.id
 
-    def save_wiki_attachment(self, path, binary):
+    def save_attachment(self, path, binary):
         filename = os.path.join(self.uploads_path, self.project_qualname, path)
         if os.path.isfile(filename):
             raise Exception("file already exists: %r" % filename)
         directory = os.path.dirname(filename)
         if not os.path.exists(directory):
             os.makedirs(directory)
-        with codecs.open(filename, "wb", encoding='utf-8') as out_f:
-            out_f.write(binary)
+        with open(filename, "wb") as bin_f:
+            bin_f.write(binary)

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -183,6 +183,15 @@ class Connection(ConnectionBase):
         M = self.model
         return M.Users.get(M.Users.email == email)
 
+    def user_exists(self, email):
+        M = self.model
+        try:
+            user = M.Users.get(M.Users.email == email)
+        except M.Users.DoesNotExist:
+            user = None
+
+        return user != None
+
     def get_user_id(self, email):
         return self.get_user(email).id
 

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -102,10 +102,10 @@ class Connection(ConnectionBase):
             LOG.debug("project %r created in namespace %r",
                       self.project_name, self.project_namespace)
 
-    def _get_project_id(self, project_name):
-        project = self._get_project(project_name)
+    def _get_project_id(self):
+        project = self._get_project(self.project_name, self.project_namespace)
         if not project:
-            raise ValueError("Project {!r} not found".format(project_name))
+            raise ValueError("Project {!r} not found".format(self.project_qualname))
         return project["id"]
 
     def _get_project(self, p_name, p_namespace=None):
@@ -169,7 +169,7 @@ class Connection(ConnectionBase):
             return None
 
     def get_project(self):
-        return self._get_project(self.project_name)
+        return self._get_project(self.project_name, self.project_namespace)
 
     def get_milestone_id(self, milestone_name):
         milestone = self.get_milestone(milestone_name)

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -83,6 +83,7 @@ class Connection(ConnectionBase):
         self.model.Notes.create_table(fail_silently=True)
         if create_missing and not self._get_project(self.project_name, self.project_namespace):
             LOG.debug("project %r doesn't exist, creating...", project_name)
+            raise ValueError('CREATE PROJECT IS BROKEN: %s:' % 'https://github.com/nazavode/tracboat/issues/37')
             # TODO check for existing namespace
             if self.project_namespace:
                 db_namespace = \

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -124,7 +124,7 @@ class Connection(ConnectionBase):
         except M.Projects.DoesNotExist:
             return None
 
-    def clear_issues(self):
+    def clear_labels(self):
         M = self.model
         # Delete all the uses of the labels of the project.
         # XXX labels could be used by merge requests as well!!!
@@ -132,7 +132,10 @@ class Connection(ConnectionBase):
             M.LabelLinks.delete().where(M.LabelLinks.label == label.id).execute()
             # You probably do not want to delete the labels themselves, otherwise you'd need to
             # set their colour every time when you re-run the migration.
-            # label.delete_instance()
+            label.delete_instance()
+
+    def clear_issues(self):
+        M = self.model
         # Delete issues and everything that goes with them...
         for issue in M.Issues.select().where(M.Issues.project == self.project_id):
             for note in M.Notes.select().where((M.Notes.project == self.project_id) &

--- a/src/tracboat/labels.py
+++ b/src/tracboat/labels.py
@@ -28,6 +28,7 @@ class LabelAbstract():
         try:
             values = ticket['attributes'][attribute_name].split(',')
         except KeyError:
+            values = []
             pass
 
         for value in values:

--- a/src/tracboat/labels.py
+++ b/src/tracboat/labels.py
@@ -110,6 +110,14 @@ class LabelManager():
         self.gitlab = gitlab
         self.logger = logger
         self.issues = {}
+        self.classes = [
+            LabelPriority,
+            LabelResolution,
+            LabelVersion,
+            LabelComponent,
+            LabelType,
+#            LabelStatus,
+        ]
 
     def collect_labels(self, tickets):
         """
@@ -145,16 +153,8 @@ class LabelManager():
         """
 
         labels = LabelSet()
-        classes = [
-            LabelPriority,
-            LabelResolution,
-            LabelVersion,
-            LabelComponent,
-            LabelType,
-            LabelStatus,
-        ]
 
-        for cls in classes:
+        for cls in self.classes:
             gen = self.factory(cls, ticket)
             labels.add_many(gen)
 

--- a/src/tracboat/labels.py
+++ b/src/tracboat/labels.py
@@ -6,6 +6,7 @@ from pprint import pprint
 class LabelAbstract():
     TYPE = None
     COLOR = None
+    ATTRIBUTE_NAME = None
     MAPPING = {}
 
     def __init__(self, title):
@@ -18,86 +19,55 @@ class LabelAbstract():
         else:
             return title
 
-    @staticmethod
-    def from_ticket(ticket):
+    @classmethod
+    def from_ticket(cls, ticket):
         """
         yield possible names from trac ticket
         """
-        pass
+        attribute_name = cls.ATTRIBUTE_NAME
+        try:
+            values = ticket['attributes'][attribute_name].split(',')
+        except KeyError:
+            pass
+
+        for value in values:
+            yield value
+
+        # get versions from changelog
+        for change in ticket['changelog']:
+            if change['field'] == attribute_name:
+                yield change['oldvalue']
+                yield change['newvalue']
 
 class LabelPriority(LabelAbstract):
     TYPE = 'priority'
     COLOR = '#D9534F'
-
-    @staticmethod
-    def from_ticket(ticket):
-        try:
-            yield ticket['attributes']['priority']
-        except KeyError:
-            pass
+    ATTRIBUTE_NAME = 'priority'
 
 class LabelResolution(LabelAbstract):
     TYPE = 'resolution'
     COLOR = '#AD8D43'
-
-    @staticmethod
-    def from_ticket(ticket):
-        try:
-            yield ticket['attributes']['resolution']
-        except KeyError:
-            pass
-
-        # get versions from changelog
-        for change in ticket['changelog']:
-            if change['field'] == 'resolution':
-                yield change['oldvalue']
-                yield change['newvalue']
+    ATTRIBUTE_NAME = 'resolution'
 
 class LabelVersion(LabelAbstract):
     TYPE = 'version'
     COLOR = '#5CB85C'
-
-    @staticmethod
-    def from_ticket(ticket):
-        try:
-            yield ticket['attributes']['version']
-        except KeyError:
-            pass
-
-        # get versions from changelog
-        for change in ticket['changelog']:
-            if change['field'] == 'version':
-                yield change['oldvalue']
-                yield change['newvalue']
+    ATTRIBUTE_NAME = 'version'
 
 class LabelComponent(LabelAbstract):
     TYPE = 'component'
     COLOR = '#8E44AD'
-
-    @staticmethod
-    def from_ticket(ticket):
-        try:
-            components = ticket['attributes']['component'].split(',')
-        except KeyError:
-            return
-
-        for comp in components:
-            yield comp
+    ATTRIBUTE_NAME = 'component'
 
 class LabelType(LabelAbstract):
     TYPE = 'type'
     COLOR = '#A295D6'
-
-    @staticmethod
-    def from_ticket(ticket):
-        try:
-            yield ticket['attributes']['type']
-        except KeyError:
-            pass
+    ATTRIBUTE_NAME = 'type'
 
 class LabelStatus(LabelAbstract):
-    TYPE = 'state'
+    TYPE = 'status'
     COLOR = '#0033CC'
+    ATTRIBUTE_NAME = 'status'
     MAPPING = {
         'new': 'opened',
         'assigned': 'opened',
@@ -105,18 +75,6 @@ class LabelStatus(LabelAbstract):
         'reopened': 'opened',
         'closed': 'closed',
     }
-
-    @staticmethod
-    def from_ticket(ticket):
-        try:
-            yield ticket['attributes']['status']
-        except KeyError:
-            pass
-
-        for change in ticket['changelog']:
-            if change['field'] == 'status':
-                yield change['oldvalue']
-                yield change['newvalue']
 
 class LabelSet():
     def __init__(self):

--- a/src/tracboat/labels.py
+++ b/src/tracboat/labels.py
@@ -9,10 +9,14 @@ class LabelAbstract():
     MAPPING = {}
 
     def __init__(self, title):
-        if title in self.MAPPING:
-            self.title = self.MAPPING[title]
+        self.title = self.convert_value(title)
+
+    @classmethod
+    def convert_value(cls, title):
+        if title in cls.MAPPING:
+            return cls.MAPPING[title]
         else:
-            self.title = title
+            return title
 
     @staticmethod
     def from_ticket(ticket):

--- a/src/tracboat/labels.py
+++ b/src/tracboat/labels.py
@@ -117,12 +117,14 @@ class LabelStatus(LabelAbstract):
 class LabelSet():
     def __init__(self):
         self.labels = {}
+        self.label_by_type = {}
 
     def __len__(self):
         return len(self.labels)
 
     def add(self, label):
         self.labels.update({label.title: label})
+        self.label_by_type[label.TYPE] = label
 
     def values(self):
         return self.labels.values()
@@ -130,6 +132,12 @@ class LabelSet():
     def add_many(self, labels):
         for label in labels:
             self.add(label)
+
+    def get_status_label(self):
+        return self.label_by_type[LabelStatus.TYPE]
+
+    def get_label_titles(self):
+        return [x.title for x in self.values()]
 
 # class handling labels management
 # when in trac we have 

--- a/src/tracboat/labels.py
+++ b/src/tracboat/labels.py
@@ -114,6 +114,22 @@ class LabelStatus(LabelAbstract):
                 yield change['oldvalue']
                 yield change['newvalue']
 
+class LabelSet():
+    def __init__(self):
+        self.labels = {}
+
+    def __len__(self):
+        return len(self.labels)
+
+    def add(self, label):
+        self.labels.update({label.title: label})
+
+    def values(self):
+        return self.labels.values()
+
+    def add_many(self, labels):
+        for label in labels:
+            self.add(label)
 
 # class handling labels management
 # when in trac we have 
@@ -132,10 +148,11 @@ class LabelManager():
 
         self.logger.info('Labels: process %d tickets', len(tickets))
         # labels of all issues
-        labels = {}
+        labels = LabelSet()
         for ticket_id, ticket in six.iteritems(tickets):
-            ticket['labels'] = self.ticket_labels(ticket)
-            [labels.update({x.title:x}) for x in ticket['labels']]
+            if not 'labels' in ticket:
+                ticket['labels'] = self.ticket_labels(ticket)
+            labels.add_many(ticket['labels'].values())
 
         return labels
 
@@ -156,7 +173,7 @@ class LabelManager():
         Get labels related to Trac ticket
         """
 
-        labels = []
+        labels = LabelSet()
         classes = [
             LabelPriority,
             LabelResolution,
@@ -168,7 +185,7 @@ class LabelManager():
 
         for cls in classes:
             gen = self.factory(cls, ticket)
-            [labels.append(x) for x in gen]
+            labels.add_many(gen)
 
         return labels
 

--- a/src/tracboat/labels.py
+++ b/src/tracboat/labels.py
@@ -146,16 +146,17 @@ class LabelManager():
         """
 
         labels = []
-        labels.extend([x for x in self.factory(LabelPriority, ticket)])
-        labels.append([x for x in self.factory(LabelResolution, ticket)])
-        labels.append([x for x in self.factory(LabelVersion, ticket)])
-        labels.append([x for x in self.factory(LabelComponent, ticket)])
-        labels.append([x for x in self.factory(LabelType, ticket)])
-        labels.append([x for x in self.factory(LabelStatus, ticket)])
-#
-#        labels = priority_labels | resolution_labels | version_labels | \
-#            component_labels | type_labels | state_labels | note_labels
-#        labels = priority_labels
+        classes = [
+            LabelPriority,
+            LabelResolution,
+            LabelVersion,
+            LabelComponent,
+            LabelType,
+            LabelStatus,
+        ]
+
+        for cls in classes:
+            labels.extend([x for x in self.factory(cls, ticket)])
 
         return labels
 

--- a/src/tracboat/labels.py
+++ b/src/tracboat/labels.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+
+import six
+from pprint import pprint
+
+class LabelAbstract():
+    TYPE = None
+    COLOR = None
+    MAPPING = {}
+
+    def __init__(self, title):
+        if title in self.MAPPING:
+            self.title = self.MAPPING[title]
+        else:
+            self.title = title
+
+    @staticmethod
+    def from_ticket(ticket):
+        """
+        yield possible names from trac ticket
+        """
+        pass
+
+class LabelPriority(LabelAbstract):
+    TYPE = 'priority'
+    COLOR = '#D9534F'
+
+    @staticmethod
+    def from_ticket(ticket):
+        try:
+            yield ticket['attributes']['priority']
+        except KeyError:
+            pass
+
+class LabelResolution(LabelAbstract):
+    TYPE = 'resolution'
+    COLOR = '#AD8D43'
+
+    @staticmethod
+    def from_ticket(ticket):
+        try:
+            yield ticket['attributes']['resolution']
+        except KeyError:
+            pass
+
+        # get versions from changelog
+        for change in ticket['changelog']:
+            if change['field'] == 'resolution':
+                yield change['oldvalue']
+                yield change['newvalue']
+
+class LabelVersion(LabelAbstract):
+    TYPE = 'version'
+    COLOR = '#5CB85C'
+
+    @staticmethod
+    def from_ticket(ticket):
+        try:
+            yield ticket['attributes']['version']
+        except KeyError:
+            pass
+
+        # get versions from changelog
+        for change in ticket['changelog']:
+            if change['field'] == 'version':
+                yield change['oldvalue']
+                yield change['newvalue']
+
+class LabelComponent(LabelAbstract):
+    TYPE = 'component'
+    COLOR = '#8E44AD'
+
+    @staticmethod
+    def from_ticket(ticket):
+        try:
+            components = ticket['attributes']['component'].split(',')
+        except KeyError:
+            return
+
+        for comp in components:
+            yield comp
+
+class LabelType(LabelAbstract):
+    TYPE = 'type'
+    COLOR = '#A295D6'
+
+    @staticmethod
+    def from_ticket(ticket):
+        try:
+            yield ticket['attributes']['type']
+        except KeyError:
+            pass
+
+class LabelStatus(LabelAbstract):
+    TYPE = 'state'
+    COLOR = '#0033CC'
+    MAPPING = {
+        'new': 'opened',
+        'assigned': 'opened',
+        'accepted': 'opened',
+        'reopened': 'opened',
+        'closed': 'closed',
+    }
+
+    @staticmethod
+    def from_ticket(ticket):
+        try:
+            yield ticket['attributes']['status']
+        except KeyError:
+            pass
+
+        for change in ticket['changelog']:
+            if change['field'] == 'status':
+                yield change['oldvalue']
+                yield change['newvalue']
+
+
+# class handling labels management
+# when in trac we have 
+# then in gitlab we have just labels
+class LabelManager():
+#    LABEL_PRIORITY = 'priority'
+#    LABEL_RESOLUTION = 'resolution'
+#    LABEL_VERSION = 'version'
+#    LABEL_COMPONENT = 'component'
+#    LABEL_TYPE = 'type'
+#    LABEL_STATE = 'state'
+
+    def __init__(self, gitlab, logger):
+        self.gitlab = gitlab
+        self.logger = logger
+        self.issues = {}
+
+    def create_labels(self, tickets):
+        """
+        Create Labels in gitlab
+        """
+        self.logger.info('Labels: process %d tickets', len(tickets))
+        for ticket_id, ticket in six.iteritems(tickets):
+            labels = self.ticket_labels(ticket)
+            pprint([x for x in labels])
+
+    def ticket_labels(self, ticket):
+        """
+        Get labels related to Trac ticket
+        """
+
+        labels = []
+        labels.extend([x for x in self.factory(LabelPriority, ticket)])
+        labels.append([x for x in self.factory(LabelResolution, ticket)])
+        labels.append([x for x in self.factory(LabelVersion, ticket)])
+        labels.append([x for x in self.factory(LabelComponent, ticket)])
+        labels.append([x for x in self.factory(LabelType, ticket)])
+        labels.append([x for x in self.factory(LabelStatus, ticket)])
+#
+#        labels = priority_labels | resolution_labels | version_labels | \
+#            component_labels | type_labels | state_labels | note_labels
+#        labels = priority_labels
+
+        return labels
+
+    def factory(self, cls, ticket):
+        for title in cls.from_ticket(ticket):
+            if title != '':
+                yield cls(title)
+
+TICKET_PRIORITY_TO_ISSUE_LABEL = {
+    'high': 'priority:high',
+    'minor': 'priority:minor',
+    'critical': 'priority:critical',
+    'blocker': 'priority:blocker',
+    # 'medium': None,
+    'major': 'priority:major',
+    'low': 'priority:low',
+    'trivial': 'priority:trivial',
+}

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -7,6 +7,7 @@ import re
 import string
 from itertools import chain
 from sys import exit
+from pprint import pprint
 
 import six
 

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -373,7 +373,7 @@ def migrate(trac, gitlab_project_name, gitlab_version, gitlab_db_connector,
                                output_uploads_path, create_missing=True)
     LOG.info('estabilished connection to GitLab database')
     # 0. Users
-    create_users(gitlab, usermap, userattrs, gitlab_fallback_user)
+    #create_users(gitlab, usermap, userattrs, gitlab_fallback_user)
 
     # XXX
     # if overwite and mode == direct

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -29,6 +29,7 @@ TICKET_PRIORITY_TO_ISSUE_LABEL = {
     # 'medium': None,
     'major': 'priority:major',
     'low': 'priority:low',
+    'trivial': 'priority:trivial',
 }
 
 TICKET_RESOLUTION_TO_ISSUE_LABEL = {

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -257,8 +257,10 @@ def milestone_kwargs(milestone):
 ################################################################################
 
 def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None):
+    LOG.info('MIGRATING %d tickets to issues', len(trac_tickets))
 
     for ticket_id, ticket in six.iteritems(trac_tickets):
+        LOG.info('migrate #%d: %r', ticket_id, ticket)
         issue_args = ticket_kwargs(ticket)
         # Fix user mapping
         issue_args['author'] = usermap.get(issue_args['author'], default_user)
@@ -272,7 +274,7 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None):
         # Create
         gitlab_issue_id = gitlab.create_issue(**issue_args)
         LOG.info('migrated ticket %s -> %s', ticket_id, gitlab_issue_id)
-#        exit(1)
+
         # Migrate whole changelog
         LOG.info('changelog: %r', ticket['changelog'])
         for change in ticket['changelog']:
@@ -289,7 +291,6 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None):
                 LOG.info('migrated ticket #%s note: %r', ticket_id, gitlab_note_id)
             else:
                 LOG.info('skip field: %s', change['field'])
-        exit(1)
 
 def migrate_milestones(trac_milestones, gitlab):
     LOG.info('migrating %d milestones', len(trac_milestones))
@@ -392,7 +393,6 @@ def migrate(trac, gitlab_project_name, gitlab_version, gitlab_db_connector,
     # 2. Milestones
     migrate_milestones(trac['milestones'], gitlab)
     # 3. Issues
-    LOG.info('migrating %d tickets to issues', len(trac['tickets']))
     migrate_tickets(trac['tickets'], gitlab, gitlab_fallback_user, usermap)
     # Farewell
     LOG.info('done migration of project %r to GitLab ver. %s', gitlab_project_name, gitlab_version)

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -263,7 +263,8 @@ def format_change_note(change, issue_id=None, note_map={}, svn2git_revisions={},
         note = '- **Attachment** [%s](%s/%s) added' % (change['newvalue'], attachments_path, change['newvalue'])
     elif field == 'cc':
         if change['newvalue'] == '':
-            raise Exception('Unexpected empty value for %s' % field)
+            LOG.error('Unexpected empty value for %s' % field)
+            return ''
 
         user = username_map.get(change['newvalue'], change['newvalue'])
         note = '- **Cc** added @%s' % change['newvalue']
@@ -272,7 +273,8 @@ def format_change_note(change, issue_id=None, note_map={}, svn2git_revisions={},
             # XXX no idea why such changes even exist
             note = ''
         elif change['newvalue'] == '':
-            raise Exception('Unexpected empty value for %s' % field)
+            LOG.error('Unexpected empty value for %s' % field)
+            return ''
 
         user = username_map.get(change['newvalue'], change['newvalue'])
         note = '- **Owner** set to @%s' % user

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -124,9 +124,7 @@ def format_change_note(change, issue_id=None, note_map={}, svn2git_revisions={},
     field = change['field']
 
     if field == 'comment':
-        note = timetracking_update(change['newvalue'], usermanager)
-        if note is None:
-            note = _wikiconvert(change['newvalue'], '/issues/', multiline=False, note_map=note_map, attachments_path=attachments_path, svn2git_revisions=svn2git_revisions)
+        note = _wikiconvert(change['newvalue'], '/issues/', multiline=False, note_map=note_map, attachments_path=attachments_path, svn2git_revisions=svn2git_revisions)
     elif field == 'resolution':
         note = format_fieldchange('Resolution', change, format_converter=format_label)
     elif field == 'priority':
@@ -340,7 +338,9 @@ def migrate_tickets(trac_tickets, gitlab, svn2git_revisions={}, labelmanager=Non
         LOG.info('changelog: %r', ticket['changelog'])
         for change in merge_changelog(ticket_id, ticket['changelog'], usermanager):
             if change['field'] == 'comment':
-                note = format_change_note(change, note_map=note_map, issue_id=ticket_id, svn2git_revisions=svn2git_revisions, usermanager=usermanager)
+                note = timetracking_update(change['newvalue'], usermanager)
+                if note is None:
+                    note = format_change_note(change, note_map=note_map, issue_id=ticket_id, svn2git_revisions=svn2git_revisions, usermanager=usermanager)
                 if note == '':
                     LOG.info('skip empty comment: change: %r', change)
                     continue

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -25,6 +25,7 @@ TICKET_PRIORITY_TO_ISSUE_LABEL = {
     'high': 'priority:high',
     'minor': 'priority:minor',
     'critical': 'priority:critical',
+    'blocker': 'priority:blocker',
     # 'medium': None,
     'major': 'priority:major',
     'low': 'priority:low',
@@ -33,6 +34,7 @@ TICKET_PRIORITY_TO_ISSUE_LABEL = {
 TICKET_RESOLUTION_TO_ISSUE_LABEL = {
     'fixed': 'closed:fixed',
     'invalid': 'closed:invalid',
+    'done': 'closed:done',
     'wontfix': 'closed:wontfix',
     'duplicate': 'closed:duplicate',
     'worksforme': 'closed:worksforme',

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -370,7 +370,7 @@ def migrate(trac, gitlab_project_name, gitlab_version, gitlab_db_connector,
     db_model = model.get_model(gitlab_version)
     LOG.info('retrieved database model for GitLab ver. %s: %r', gitlab_version, db_model.__file__)
     gitlab = direct.Connection(gitlab_project_name, db_model, gitlab_db_connector,
-                               output_uploads_path, create_missing=True)
+                               output_uploads_path, create_missing=False)
     LOG.info('estabilished connection to GitLab database')
     # 0. Users
     #create_users(gitlab, usermap, userattrs, gitlab_fallback_user)

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -17,7 +17,7 @@ from tracboat.gitlab import model
 __all__ = ['migrate']
 
 LOG = logging.getLogger(__name__)
-logging.basicConfig(filename='comment.log', filemode='w', level=logging.INFO)
+#logging.basicConfig(filename='comment.log', filemode='w', level=logging.INFO)
 
 TICKET_PRIORITY_TO_ISSUE_LABEL = {
     'high': 'prio:high',

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -299,7 +299,10 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None):
                 gitlab_note_id = gitlab.comment_issue( issue_id=gitlab_issue_id, binary_attachment=None, **note_args)
                 LOG.info('migrated ticket #%s note: %r', ticket_id, gitlab_note_id)
             else:
+                # TODO: skip field: description
                 LOG.info('skip field: %s', change['field'])
+                from pprint import pprint
+                pprint(change)
 
 def migrate_milestones(trac_milestones, gitlab):
     LOG.info('migrating %d milestones', len(trac_milestones))

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -143,12 +143,6 @@ def ticket_type(ticket):
     ttype = ticket['attributes']['type']
     return {'type:{}'.format(ttype.strip())}
 
-def gitlab_status_label(status, status_to_state=None):
-    status_to_state = status_to_state or TICKET_STATE_TO_ISSUE_STATE
-    if status in status_to_state:
-        return status_to_state[status]
-    else:
-        raise Exception('No label for "%s" status' % status)
 
 def gitlab_status_label(status, status_to_state=None):
     status_to_state = status_to_state or TICKET_STATE_TO_ISSUE_STATE

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -313,7 +313,7 @@ def change_comment_kwargs(change, note):
         # 'project'
     }
 
-def ticket_kwargs(ticket):
+def ticket_kwargs(ticket_id, ticket):
     priority_labels = ticket_priority(ticket)
     resolution_labels = ticket_resolution(ticket)
     version_labels = ticket_versions(ticket)
@@ -328,7 +328,9 @@ def ticket_kwargs(ticket):
     return {
         'title': ticket['attributes']['summary'],
         'description': _wikiconvert(ticket['attributes']['description'],
-                                    '/issues/', multiline=False),
+                                    '/issues/', multiline=False,
+                                    attachments_path = '/uploads/issue_%s' % ticket_id
+        ),
         'state': state,
         'labels': ','.join(labels),
         'created_at': ticket['attributes']['time'],
@@ -419,7 +421,7 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None, svn2git_re
         note_map = {}
         trac_note_id = 1
 
-        issue_args = ticket_kwargs(ticket)
+        issue_args = ticket_kwargs(ticket_id, ticket)
         # Fix user mapping
         issue_args['author'] = usermap.get(issue_args['author'], default_user)
         issue_args['assignee'] = usermap.get(issue_args['assignee'], default_user)

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -228,7 +228,7 @@ def change_kwargs(change, issue_id=None, note_map={}, svn2git_revisions={}):
         elif change['oldvalue'] != '':
             oldvalue = gitlab_priority_label(change['oldvalue'])
             newvalue = gitlab_priority_label(change['newvalue'])
-            note = '- **Priority** changed from ~"**%s**" to ~"**%s**"' % (oldvalue, newvalue)
+            note = '- **Priority** changed from ~"%s" to ~"%s"' % (oldvalue, newvalue)
         else:
             label = gitlab_priority_label(change['newvalue'])
             note = '- **Priority** set to ~"%s"' % label
@@ -241,11 +241,11 @@ def change_kwargs(change, issue_id=None, note_map={}, svn2git_revisions={}):
             note = '- **Milestone** set to %%"%s"' % change['newvalue']
     elif change['field'] == 'estimatedhours':
         if change['newvalue'] == '':
-            note = '- **Estimated Hours** "%s" deleted' % change['oldvalue']
+            note = '- **Estimated Hours** *%s* deleted' % change['oldvalue']
         elif change['oldvalue'] != '':
-            note = '- **Estimated Hours** changed from "**%s**" to "**%s**"' % (change['oldvalue'], change['newvalue'])
+            note = '- **Estimated Hours** changed from *%s* to *%s*' % (change['oldvalue'], change['newvalue'])
         else:
-            note = '- **Estimated Hours** set to "%s"' % change['newvalue']
+            note = '- **Estimated Hours** set to *%s*' % change['newvalue']
     elif change['field'] == 'version':
         if change['newvalue'] == '':
             note = '- **Version** ~"version:%s" deleted' % change['oldvalue']
@@ -260,9 +260,9 @@ def change_kwargs(change, issue_id=None, note_map={}, svn2git_revisions={}):
     elif change['field'] == 'summary':
         if change['oldvalue'] == '':
             # XXX: does this happen or we need only 'diff' render?
-            note = '- **Summary** changed to "**%s**"' % change['newvalue']
+            note = '- **Summary** changed to *%s*' % change['newvalue']
         else:
-            note = '- **Summary** changed from "**%s**" to "**%s**"' % (change['oldvalue'], change['newvalue'])
+            note = '- **Summary** changed from *%s* to *%s*' % (change['oldvalue'], change['newvalue'])
     elif change['field'] == 'attachment':
         # ![20170905_134928](/uploads/f38feb8a3dc4c5bcabdc41ccc5894ac3/20170905_134928.jpg)
         # will be saved  relative to the project:
@@ -284,7 +284,7 @@ def change_kwargs(change, issue_id=None, note_map={}, svn2git_revisions={}):
     elif change['field'] == 'status':
         oldstatus = gitlab_status_label(change['oldvalue'])
         newstatus = gitlab_status_label(change['newvalue'])
-        note = "- **Status** changed from *%s* to *%s*" % (oldstatus, newstatus)
+        note = '- **Status** changed from ~"%s" to ~"%s"' % (oldstatus, newstatus)
     else:
         raise Exception('Unexpected field %s' % change['field'])
 

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -278,7 +278,9 @@ def format_change_note(change, issue_id=None, note_map={}, svn2git_revisions={},
     else:
         raise Exception('Unexpected field %s' % field)
 
-    return note
+    # ensure we do not yield empty note
+    # https://gitlab.com/gitlab-org/gitlab-ce/issues/40297#note_47872749
+    return note.strip()
 
 def change_comment_kwargs(change, note):
     """

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -216,18 +216,19 @@ def format_change_note(change, issue_id=None, note_map={}, svn2git_revisions={})
     """
 
     attachments_path = '/uploads/issue_%s' % issue_id
+    field = change['field']
 
-    if change['field'] == 'comment':
+    if field == 'comment':
         note = _wikiconvert(change['newvalue'], '/issues/', multiline=False, note_map=note_map, attachments_path=attachments_path, svn2git_revisions=svn2git_revisions)
 
-    elif change['field'] == 'resolution':
+    elif field == 'resolution':
         if change['newvalue'] == '':
             resolution = gitlab_resolution_label(change['oldvalue'])
             note = '- **Resolution** ~"%s" deleted' % resolution
         else:
             resolution = gitlab_resolution_label(change['newvalue'])
             note = '- **Resolution** set to ~"%s"' % resolution
-    elif change['field'] == 'priority':
+    elif field == 'priority':
         if change['newvalue'] == '':
             label = gitlab_priority_label(change['oldvalue'])
             note = '- **Priority** ~"%s" deleted' % label
@@ -238,61 +239,61 @@ def format_change_note(change, issue_id=None, note_map={}, svn2git_revisions={})
         else:
             label = gitlab_priority_label(change['newvalue'])
             note = '- **Priority** set to ~"%s"' % label
-    elif change['field'] == 'milestone':
+    elif field == 'milestone':
         if change['newvalue'] == '':
             note = '- **Milestone** %%"%s" deleted' % change['oldvalue']
         elif change['oldvalue'] != '':
             note = '- **Milestone** changed from %%"%s" to %%"%s"' % (change['oldvalue'], change['newvalue'])
         else:
             note = '- **Milestone** set to %%"%s"' % change['newvalue']
-    elif change['field'] == 'estimatedhours':
+    elif field == 'estimatedhours':
         if change['newvalue'] == '':
             note = '- **Estimated Hours** *%s* deleted' % change['oldvalue']
         elif change['oldvalue'] != '':
             note = '- **Estimated Hours** changed from *%s* to *%s*' % (change['oldvalue'], change['newvalue'])
         else:
             note = '- **Estimated Hours** set to *%s*' % change['newvalue']
-    elif change['field'] == 'version':
+    elif field == 'version':
         if change['newvalue'] == '':
             note = '- **Version** ~"version:%s" deleted' % change['oldvalue']
         else:
             note = '- **Version** set to ~"version:%s"' % change['newvalue']
-    elif change['field'] == 'description':
+    elif field == 'description':
         if change['oldvalue'] == '':
             # XXX: does this happen or we need only 'diff' render?
             note = '- **Description** changed\n\n%s' % render_html5_details(change['newvalue'])
         else:
             note = '- **Description** changed\n\n%s' % render_text_diff(change['oldvalue'], change['newvalue'])
-    elif change['field'] == 'summary':
+    elif field == 'summary':
         if change['oldvalue'] == '':
             # XXX: does this happen or we need only 'diff' render?
             note = '- **Summary** changed to *%s*' % change['newvalue']
         else:
             note = '- **Summary** changed from *%s* to *%s*' % (change['oldvalue'], change['newvalue'])
-    elif change['field'] == 'attachment':
+    elif field == 'attachment':
         # ![20170905_134928](/uploads/f38feb8a3dc4c5bcabdc41ccc5894ac3/20170905_134928.jpg)
         # will be saved  relative to the project:
         # /var/opt/gitlab/gitlab-rails/uploads/glen/photoproject/f38feb8a3dc4c5bcabdc41ccc5894ac3
         note = '- **Attachment** [%s](%s/%s) added' % (change['newvalue'], attachments_path, change['newvalue'])
-    elif change['field'] == 'cc':
+    elif field == 'cc':
         if change['newvalue'] == '':
-            raise Exception('Unexpected empty value for %s' % change['field'])
+            raise Exception('Unexpected empty value for %s' % field)
 
         note = '- **Cc** added @%s' % change['newvalue']
-    elif change['field'] == 'owner':
+    elif field == 'owner':
         if change['oldvalue'] == '' and change['newvalue'] == '':
             # XXX no idea why such changes even exist
             note = ''
         elif change['newvalue'] == '':
-            raise Exception('Unexpected empty value for %s' % change['field'])
+            raise Exception('Unexpected empty value for %s' % field)
 
         note = '- **Owner** set to @%s' % change['newvalue']
-    elif change['field'] == 'status':
+    elif field == 'status':
         oldstatus = gitlab_status_label(change['oldvalue'])
         newstatus = gitlab_status_label(change['newvalue'])
         note = '- **Status** changed from ~"%s" to ~"%s"' % (oldstatus, newstatus)
     else:
-        raise Exception('Unexpected field %s' % change['field'])
+        raise Exception('Unexpected field %s' % field)
 
     return note
 

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -205,7 +205,6 @@ def ticket_kwargs(ticket_id, ticket):
                                     '/issues/', multiline=False,
                                     attachments_path = '/uploads/issue_%s' % ticket_id
         ),
-        'state': state,
         'created_at': ticket['attributes']['time'],
         'updated_at': ticket['attributes']['changetime'],
         # References:
@@ -300,7 +299,9 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None, svn2git_re
         trac_note_id = 1
 
         issue_args = ticket_kwargs(ticket_id, ticket)
-        issue_args['labels'] = ','.join([x.title for x in labelmanager.ticket_labels(ticket).values()])
+        label_set = ticket['labels']
+        issue_args['state'] = label_set.get_status_label().title
+        issue_args['labels'] = ','.join(label_set.get_label_titles())
         # Fix user mapping
         issue_args['author'] = usermap.get(issue_args['author'], default_user)
         issue_args['assignee'] = usermap.get(issue_args['assignee'], default_user)

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -295,7 +295,8 @@ def update_timetracking(issue_args, ticket):
     # timelogs
     issue_args['time_spent'] = convert(ticket['attributes']['totalhours'])
     # issue.time_estimate
-    issue_args['time_estimate'] = convert(ticket['attributes']['estimatedhours'])
+    if 'estimatedhours' in ticket['attributes']:
+        issue_args['time_estimate'] = convert(ticket['attributes']['estimatedhours'])
 
 def migrate_tickets(trac_tickets, gitlab, svn2git_revisions={}, labelmanager=None, usermanager=None):
     LOG.info('MIGRATING %d tickets to issues', len(trac_tickets))

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -280,7 +280,7 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None):
         LOG.info('changelog: %r', ticket['changelog'])
         for change in sort_changelog(ticket['changelog']):
             if change['field'] in ['comment', 'resolution', 'status']:
-                note_args = change_kwargs(change)
+                note_args = change_kwargs(change, note_map=note_map)
                 if note_args['note'] == '':
                     LOG.info('skip empty comment: %r; change: %r', note_args, change)
                     continue
@@ -293,11 +293,11 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None):
 
                 if change['field'] == 'comment':
                     note_map[trac_note_id] = gitlab_note_id
+                    pprint(['NOTE_MAP[#%s] %s -> %s' % (gitlab_issue_id, trac_note_id, gitlab_note_id), note_map])
                     trac_note_id += 1
             else:
                 # TODO: skip field: description
                 LOG.info('skip field: %s', change['field'])
-                #pprint(change)
 
 def migrate_milestones(trac_milestones, gitlab):
     LOG.info('migrating %d milestones', len(trac_milestones))

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -86,13 +86,6 @@ def gitlab_resolution_label(resolution, resolution_to_label=None):
     if resolution in resolution_to_label:
         return resolution_to_label[resolution]
     else:
-        raise Exception('No label for "%s" resolution' % resolution)
-
-def gitlab_resolution_label(resolution, resolution_to_label=None):
-    resolution_to_label = resolution_to_label or TICKET_RESOLUTION_TO_ISSUE_LABEL
-    if resolution in resolution_to_label:
-        return resolution_to_label[resolution]
-    else:
         # todo find a meaningful default value for unknown resolutions
         raise ValueError('no label for {} resolution'.format(resolution))
 

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -131,7 +131,7 @@ def format_change_note(change, issue_id=None, note_map={}, svn2git_revisions={},
             return ''
 
         user = usermanager.get_login(change['newvalue'], change['newvalue'])
-        note = '- **Cc** added @%s' % change['newvalue']
+        note = '- **Cc** added @%s' % user
     elif field == 'owner':
         if change['oldvalue'] == '' and change['newvalue'] == '':
             # XXX no idea why such changes even exist

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -454,8 +454,7 @@ def migrate(trac, gitlab_project_name, gitlab_version, gitlab_db_connector,
     migrate_milestones(trac['milestones'], gitlab)
 
     labelmanager = LabelManager(gitlab, LOG)
-    labelmanager.create_labels(trac['tickets'])
-    labels = {}
+    labels = labelmanager.create_labels(trac['tickets'])
     exit(3)
 
     # 3. Issues

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -235,7 +235,7 @@ def change_kwargs(change, ticket_id=None, note_map={}):
         if change['newvalue'] == '':
             note = '- **Milestone** %%"%s" deleted' % change['oldvalue']
         elif change['oldvalue'] != '':
-            note = '- **Milestone** changed from %%"**%s**" to %%"**%s**"' % (change['oldvalue'], change['newvalue'])
+            note = '- **Milestone** changed from %%"%s" to %%"%s"' % (change['oldvalue'], change['newvalue'])
         else:
             note = '- **Milestone** set to %%"%s"' % change['newvalue']
     elif change['field'] == 'estimatedhours':

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -100,17 +100,29 @@ def ticket_resolution(ticket, resolution_to_label=None):
         return set()
 
 
-def ticket_version(ticket):
+def version_label(version):
+    return 'version:{}'.format(version)
+
+def ticket_versions(ticket):
+    labels = set()
+
     try:
-        version = ticket['attributes']['version']
+        labels.add(version_label(ticket['attributes']['version']))
     except KeyError:
-        return set()
+        pass
 
-    if version:
-        return {'version:{}'.format(version)}
-    else:
-        return set()
+    def add_version(labels, version):
+        if version == '':
+            return
+        labels.add(version_label(version))
 
+    # get versions from changelog
+    for change in ticket['changelog']:
+        if change['field'] == 'version':
+            add_version(labels, change['oldvalue'])
+            add_version(labels, change['newvalue'])
+
+    return labels
 
 def ticket_components(ticket):
     components = ticket['attributes']['component'].split(',')
@@ -222,7 +234,7 @@ def change_kwargs(change, note_map = {}):
 def ticket_kwargs(ticket):
     priority_labels = ticket_priority(ticket)
     resolution_labels = ticket_resolution(ticket)
-    version_labels = ticket_version(ticket)
+    version_labels = ticket_versions(ticket)
     component_labels = ticket_components(ticket)
     type_labels = ticket_type(ticket)
     state, state_labels = ticket_state(ticket)

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -264,6 +264,16 @@ def ticket_state(ticket):
     state = ticket['attributes']['status']
     return status_to_state[state]
 
+def update_timetracking(issue_args, ticket):
+    def convert(hours):
+        seconds = float(hours) * 60 * 60
+        return seconds
+
+    # timelogs
+    issue_args['time_spent'] = convert(ticket['attributes']['totalhours'])
+    # issue.time_estimate
+    issue_args['time_estimate'] = convert(ticket['attributes']['estimatedhours'])
+
 def migrate_tickets(trac_tickets, gitlab, svn2git_revisions={}, labelmanager=None, usermanager=None):
     LOG.info('MIGRATING %d tickets to issues', len(trac_tickets))
 
@@ -283,6 +293,8 @@ def migrate_tickets(trac_tickets, gitlab, svn2git_revisions={}, labelmanager=Non
         issue_args['labels'] = ','.join(label_set.get_label_titles())
         issue_args['author'] = usermanager.get_email(issue_args['author'])
         issue_args['assignee'] = usermanager.get_email(issue_args['assignee'])
+
+        update_timetracking(issue_args, ticket)
 
         issue_args['iid'] = ticket_id
 

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -165,13 +165,16 @@ def change_comment_kwargs(change, note):
         # 'project'
     }
 
-def ticket_kwargs(ticket_id, ticket):
+def ticket_kwargs(ticket_id, ticket, svn2git_revisions={}):
+
+    description = _wikiconvert(ticket['attributes']['description'], '/issues/', multiline=False,
+        attachments_path='/uploads/issue_%s' % ticket_id,
+        svn2git_revisions=svn2git_revisions
+    )
+
     return {
         'title': ticket['attributes']['summary'],
-        'description': _wikiconvert(ticket['attributes']['description'],
-                                    '/issues/', multiline=False,
-                                    attachments_path = '/uploads/issue_%s' % ticket_id
-        ),
+        'description': description,
         'created_at': ticket['attributes']['time'],
         'updated_at': ticket['attributes']['changetime'],
         # References:
@@ -265,7 +268,7 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None, svn2git_re
         note_map = {}
         trac_note_id = 1
 
-        issue_args = ticket_kwargs(ticket_id, ticket)
+        issue_args = ticket_kwargs(ticket_id, ticket, svn2git_revisions=svn2git_revisions)
         label_set = ticket['labels']
         issue_args['state'] = label_set.get_status_label().title
         issue_args['labels'] = ','.join(label_set.get_label_titles())

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -414,6 +414,7 @@ def migrate(trac, gitlab_project_name, gitlab_version, gitlab_db_connector,
     # XXX: this clears also milestones
     # XXX: make configurable
     gitlab.clear_issues()
+#    gitlab.clear_labels()
 
     # 1. Wiki
 #    LOG.info('migrating %d wiki pages to: %s', len(trac['wiki']), output_wiki_path)

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -211,7 +211,7 @@ def change_kwargs(change, ticket_id=None, note_map={}):
         # ![20170905_134928](/uploads/f38feb8a3dc4c5bcabdc41ccc5894ac3/20170905_134928.jpg)
         # will be saved  relative to the project:
         # /var/opt/gitlab/gitlab-rails/uploads/glen/photoproject/f38feb8a3dc4c5bcabdc41ccc5894ac3
-        note = '- **Attachment** [%s](/uploads/migrated/%s/%s) added' % (change['newvalue'], ticket_id, change['newvalue'])
+        note = '- **Attachment** [%s](/uploads/issue_%s/%s) added' % (change['newvalue'], ticket_id, change['newvalue'])
     elif change['field'] == 'status':
         oldstatus = gitlab_status_label(change['oldvalue'])
         newstatus = gitlab_status_label(change['newvalue'])
@@ -353,7 +353,7 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None):
         for filename, attachment in six.iteritems(ticket['attachments']):
             attrs = attachment['attributes']
             LOG.info('saving attachment: %s (%d bytes) author: %s, description: %s' % (filename, attrs['size'], attrs['author'], attrs['description']))
-            gitlab.save_attachment('migrated/%s/%s' % (ticket_id, filename), attachment['data'])
+            gitlab.save_attachment('issue_%s/%s' % (ticket_id, filename), attachment['data'])
 
         # Migrate whole changelog
         LOG.info('changelog: %r', ticket['changelog'])

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -196,7 +196,10 @@ def change_kwargs(change, note_map = {}):
         else:
             note = '- **Description** changed from "**%s**" to "**%s**"' % (change['oldvalue'], change['newvalue'])
     elif change['field'] == 'attachment':
-        note = '- **Attachment** [%s](%s) added' % (change['newvalue'], change['newvalue'])
+        # ![20170905_134928](/uploads/f38feb8a3dc4c5bcabdc41ccc5894ac3/20170905_134928.jpg)
+        # will be saved  relative to the project:
+        # /var/opt/gitlab/gitlab-rails/uploads/glen/photoproject/f38feb8a3dc4c5bcabdc41ccc5894ac3
+        note = '- **Attachment** [%s](/uploads/migrated/%s) added' % (change['newvalue'], change['newvalue'])
     elif change['field'] == 'status':
         oldstatus = gitlab_status_label(change['oldvalue'])
         newstatus = gitlab_status_label(change['newvalue'])

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -48,31 +48,11 @@ TICKET_STATE_TO_ISSUE_STATE = {
     'closed': 'closed',
 }
 
-################################################################################
-# Wiki format normalization
-################################################################################
-
-CHANGESET_REX = re.compile(
-    r'(?sm)In \[changeset:"([^"/]+?)(?:/[^"]+)?"\]:\n\{\{\{(\n#![^\n]+)?\n(.*?)\n\}\}\}'
-)
-
-CHANGESET2_REX = re.compile(
-    r'\[changeset:([a-zA-Z0-9]+)\]'
-)
-
-
 def _format_changeset_comment(rex):
     return 'In changeset ' + rex.group(1) + ':\n> ' + rex.group(3).replace('\n', '\n> ')
 
-
-def _wikifix(text):
-    text = CHANGESET_REX.sub(_format_changeset_comment, text)
-    text = CHANGESET2_REX.sub(r'\1', text)
-    return text
-
-
 def _wikiconvert(text, basepath, multiline=True, note_map={}, attachments_path=None, svn2git_revisions={}):
-    return trac2down.convert(_wikifix(text), basepath, multiline, note_map=note_map, attachments_path=attachments_path, svn2git_revisions=svn2git_revisions)
+    return trac2down.convert(text, basepath, multiline, note_map=note_map, attachments_path=attachments_path, svn2git_revisions=svn2git_revisions)
 
 
 ################################################################################

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -459,6 +459,9 @@ def migrate_tickets(trac_tickets, gitlab, default_user, usermap=None, svn2git_re
                 # skip field: type
                 LOG.info('skip field: %s', change['field'])
 
+        # process 1 ticket only
+#        return
+
 # for ticket comments to appear normally, we created all milestones as 'active'
 # now close the milestones that are 'closed'
 def close_milestones(trac_milestones, gitlab):
@@ -564,6 +567,7 @@ def migrate(trac, gitlab_project_name, gitlab_version, gitlab_db_connector,
     migrate_milestones(trac['milestones'], gitlab)
     # 3. Issues
     migrate_tickets(trac['tickets'], gitlab, gitlab_fallback_user, usermap, svn2git_revisions=svn2git_revisions)
-    #close_milestones(trac['milestones'], gitlab) - gitlab bug?
+    # - gitlab bug?
+    close_milestones(trac['milestones'], gitlab)
     # Farewell
     LOG.info('done migration of project %r to GitLab ver. %s', gitlab_project_name, gitlab_version)

--- a/src/tracboat/trac.py
+++ b/src/tracboat/trac.py
@@ -25,7 +25,8 @@ def _authors_collect(wiki=None, tickets=None):
         [page['attributes']['author'] for page in six.itervalues(wiki)] +
         [ticket['attributes']['reporter'] for ticket in six.itervalues(tickets)] +
         [ticket['attributes']['owner'] for ticket in six.itervalues(tickets)] +
-        [change['author'] for ticket in six.itervalues(tickets) for change in ticket['changelog']]
+        [change['author'] for ticket in six.itervalues(tickets) for change in ticket['changelog']] +
+        [change['newvalue'] for ticket in six.itervalues(tickets) for change in ticket['changelog'] if change['field'] in ['cc', 'owner']]
     ))
 
 

--- a/src/tracboat/trac.py
+++ b/src/tracboat/trac.py
@@ -37,6 +37,8 @@ def ticket_get_attributes(source, ticket_id):
 
 def ticket_get_changelog(source, ticket_id):
     LOG.debug('ticket_get_changelog of ticket #%s', ticket_id)
+    # the results are ordered by time,permanent,author tuple
+    # https://trac.edgewall.org/browser/tags/trac-1.0.15/trac/ticket/model.py#L383
     return [
         {
             'time': c[0],

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -143,10 +143,10 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
         return "Replying to [%(username)s](%(link)s):" % d
 
     commit_re = re.compile(r"""
-        \[(?P<revision>\d+)\] # revision in brackets
+        \[(?P<revision>\d+)(?P<subtrac>/[^/]+)?\] # revision in brackets
         | r(?P<revision2>\d+) # revision with r-prefix
         | \[(?P<rev1>\d+)-(?P<rev2>\d+)\] # revision range
-        | changeset:(?P<changeset>\d+)
+        | changeset:"?(?P<changeset>\d+)"?
     """, re.X)
     def commit_replace(m):
         """
@@ -154,6 +154,7 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
         [36859], [36860]
         Changesets [36872-36874]
         changeset:38934
+        [changeset:"65152"]
         """
         d = m.groupdict()
         d[0] = str(m.group(0))

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -53,9 +53,9 @@ def convert(text, base_path, multilines=True, note_map={}):
 
         d = m.groupdict()
         # fallback to original id, can be fixed manually after import
-        pprint(note_map)
-#        note_id = note_map.get(d['comment_id'], d['comment_id'])
-        note_id = note_map.get(d['comment_id'])
+        pprint(['WIKI_NOTE_MAP for %s' % d['comment_id'], note_map])
+        comment_id = int(d['comment_id'])
+        note_id = note_map.get(comment_id, comment_id)
         d['link'] = '#note_%s' % note_id
 
         return "Replying to [%(username)s](%(link)s):" % d

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -208,20 +208,6 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
             else:
                 return '![%(path)s](%(upload_path)s)' % d
 
-    timetracking_re = re.compile(r"""
-        \[/hours/(?P<ticket>\d+)\t(?P<hours>[\d.]+)\thours\]\tlogged\tfor\t(?P<login>\S+):\t(?P<message>.+)
-    """, re.X)
-    def timetracking_replace(m):
-        """
-        u'[/hours/59\t2.2\thours]\tlogged\tfor\tsome-user:\t_some\tmessage\there_',
-        """
-        d = m.groupdict()
-
-        # message whitespace is tab separated, change to spaces
-        d['message'] = d['message'].replace("\t", " ")
-
-        return "%(hours)s logged by @%(login)s: %(message)s" % d
-
     a = []
     is_table = False
     for line in text.split('\n'):
@@ -237,7 +223,6 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
             line = reply_re.sub(reply_replace, line)
             line = attachment_re.sub(attachment_replace, line)
             line = commit_re.sub(commit_replace, line)
-            line = timetracking_re.sub(timetracking_replace, line)
 
             # bold
             line = re.sub(r"'''(.*?)'''", r'**\1**', line)

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -208,6 +208,20 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
             else:
                 return '![%(path)s](%(upload_path)s)' % d
 
+    timetracking_re = re.compile(r"""
+        \[/hours/(?P<ticket>\d+)\t(?P<hours>[\d.]+)\thours\]\tlogged\tfor\t(?P<login>\S+):\t(?P<message>.+)
+    """, re.X)
+    def timetracking_replace(m):
+        """
+        u'[/hours/59\t2.2\thours]\tlogged\tfor\tsome-user:\t_some\tmessage\there_',
+        """
+        d = m.groupdict()
+
+        # message whitespace is tab separated, change to spaces
+        d['message'] = d['message'].replace("\t", " ")
+
+        return "%(hours)s logged by @%(login)s: %(message)s" % d
+
     a = []
     is_table = False
     for line in text.split('\n'):
@@ -223,6 +237,7 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
             line = reply_re.sub(reply_replace, line)
             line = attachment_re.sub(attachment_replace, line)
             line = commit_re.sub(commit_replace, line)
+            line = timetracking_re.sub(timetracking_replace, line)
 
             # bold
             line = re.sub(r"'''(.*?)'''", r'**\1**', line)

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -42,10 +42,11 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
     text = re.sub(r'(?m)^===\s+(.*?)\s+===$', r'### \1', text)
     text = re.sub(r'(?m)^==\s+(.*?)\s+==$', r'## \1', text)
     text = re.sub(r'(?m)^=\s+(.*?)\s+=$', r'# \1', text)
-    text = re.sub(r'^             * ', r'****', text)
-    text = re.sub(r'^         * ', r'***', text)
-    text = re.sub(r'^     * ', r'**', text)
-    text = re.sub(r'^ * ', r'*', text)
+    # what these are supposed to do? space + unlimited space? forgotten \* escape?
+#    text = re.sub(r'^             * ', r'****', text)
+#    text = re.sub(r'^         * ', r'***', text)
+#    text = re.sub(r'^     * ', r'**', text)
+#    text = re.sub(r'^ * ', r'*', text)
     text = re.sub(r'^ \d+. ', r'1.', text)
 
     # https://stackoverflow.com/a/16891418/2314626

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -24,7 +24,6 @@ from sys import exit
 
 import six
 
-
 def convert(text, base_path, multilines=True, note_map={}, attachments_path=None, svn2git_revisions={}):
     text = re.sub('\r\n', '\n', text)
     text = re.sub(r'{{{(.*?)}}}', r'`\1`', text)
@@ -62,7 +61,9 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
                     (:(?P<id>.+?))? # match optional id (optional with type)
                 )?
             )
-        \]\]
+        \]\] |
+        # alternative without brackets
+        attachment:(?P<filename2>\S+)
     """, re.X)
     def attachment_replace(m):
         """
@@ -80,6 +81,8 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
         """
         d = m.groupdict()
         d['attachments_path'] = attachments_path
+        if d['filename2']:
+            d['filename'] = d['filename2']
         return "[%(filename)s](%(attachments_path)s/%(filename)s)" % d
 
     source_re = re.compile(r"""
@@ -89,7 +92,7 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
         \] |
 
         # alternative without brackets
-        source:(?P<path2>[\S]+)
+        source:(?P<path2>\S+)
 
     """, re.X)
     def source_replace(m):

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -163,7 +163,7 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
             return "[%(rev1)s..%(rev2)s](../compare/%(rev1)s...%(rev2)s)" % d
         else:
             if d['changeset']:
-                revision = str(d.get('changeset'))
+                revision = str(d['changeset'])
             else:
                 if d['revision2']:
                     d['revision'] = d['revision2']

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -165,7 +165,9 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
             if d['changeset']:
                 revision = str(d.get('changeset'))
             else:
-                revision = str(d.get('revision', d.get('revision2')))
+                if d['revision2']:
+                    d['revision'] = d['revision2']
+                revision = str(d['revision'])
             d['git_hash'] = svn2git_revisions.get(revision, d[0])
 
             return "%(git_hash)s" % d

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -87,13 +87,12 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
 
     source_re = re.compile(r"""
         # default one with brackets
-        \[source:
+        \[(?:source|browser):
             (?P<path>[^]]+)
-        \] |
+        \]
 
         # alternative without brackets
-        source:(?P<path2>\S+)
-
+        | (?:source|browser):(?P<path2>\S+)
     """, re.X)
     def source_replace(m):
         """
@@ -111,9 +110,11 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
 
         """
         d = m.groupdict()
-        path = str(d.get('path', d.get('path2')))
-        path = remove_prefix(path, '/trunk/') # remove branch name, assume default branch
+        if d['path2']:
+            d['path'] = d['path2']
+        path = str(d.get('path'))
         path = remove_prefix(path, '/') # remove leading slash, it would not point to source otherwise
+        path = remove_prefix(path, 'trunk/') # remove branch name, assume default branch
         d.update({
             'git_path' : path,
         })

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -98,18 +98,19 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
         return "Replying to [%(username)s](%(link)s):" % d
 
     commit_re = re.compile(r"""
-        \(In\s\[(?P<revision>\d+)\]\)
+        \[(?P<revision>\d+)\] |
+        r(?P<revision2>\d+)
     """, re.X)
     def commit_replace(m):
         """
         (In [35214])
         """
         d = m.groupdict()
-        revision = str(d['revision'])
-        d['git_hash'] = svn2git_revisions.get(revision, "[%s]" % d['revision'])
-        pprint("GIT MAP: (%s) r=%r; d=%r" % (type(svn2git_revisions), revision, d))
+        d[0] = str(m.group(0))
+        revision = str(d.get('revision', d.get('revision2')))
+        d['git_hash'] = svn2git_revisions.get(revision, d[0])
 
-        return "(In %(git_hash)s)" % d
+        return "%(git_hash)s" % d
 
     image_re = re.compile(r'\[\[Image\((?:(?P<module>(?:source|wiki)):)?(?P<path>[^)]+)\)\]\]')
     def image_replace(m):

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -16,11 +16,12 @@ import datetime
 import re
 import os
 import codecs
+from pprint import pprint
 
 import six
 
 
-def convert(text, base_path, multilines=True):
+def convert(text, base_path, multilines=True, note_map={}):
     text = re.sub('\r\n', '\n', text)
     text = re.sub(r'{{{(.*?)}}}', r'`\1`', text)
     text = re.sub(r'(?sm){{{(\n?#![^\n]+)?\n(.*?)\n}}}', r'```\n\2\n```', text)
@@ -51,8 +52,11 @@ def convert(text, base_path, multilines=True):
         """
 
         d = m.groupdict()
-        # NOTE: the comment_id is bogus, should be fixed manually after import
-        d['link'] = '#note_%s' % d['comment_id']
+        # fallback to original id, can be fixed manually after import
+        pprint(note_map)
+#        note_id = note_map.get(d['comment_id'], d['comment_id'])
+        note_id = note_map.get(d['comment_id'])
+        d['link'] = '#note_%s' % note_id
 
         return "Replying to [%(username)s](%(link)s):" % d
 

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -105,6 +105,7 @@ def convert(text, base_path, multilines=True, note_map={}):
     a = []
     is_table = False
     for line in text.split('\n'):
+        # not blockquote?
         if not line.startswith('    '):
             line = re.sub(r'\[(https?://[^\s\[\]]+)\s([^\[\]]+)\]', r'[\2](\1)', line)
             line = re.sub(r'\[wiki:([^\s\[\]]+)\s([^\[\]]+)\]', r'[\2](%s/\1)' % os.path.relpath('/wikis/', base_path), line)
@@ -116,8 +117,11 @@ def convert(text, base_path, multilines=True, note_map={}):
             line = image_re.sub(image_replace, line)
             line = reply_re.sub(reply_replace, line)
 
-            line = re.sub(r'\'\'\'(.*?)\'\'\'', r'*\1*', line)
-            line = re.sub(r'\'\'(.*?)\'\'', r'_\1_', line)
+            # bold
+            line = re.sub(r"'''(.*?)'''", r'**\1**', line)
+            # italic
+            line = re.sub(r"''(.*?)''", r'_\1_', line)
+            # tables?
             if line.startswith('||'):
                 if not is_table:
                     sep = re.sub(r'[^|]', r'-', line)

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -45,18 +45,24 @@ def convert(text, base_path, multilines=True, note_map={}):
     text = re.sub(r'^ * ', r'*', text)
     text = re.sub(r'^ \d+. ', r'1.', text)
 
-    reply_re = re.compile(r'Replying to \[comment:(?P<comment_id>\d+)\s+(?P<username>[^]]+)\]:')
+    reply_re = re.compile(r'Replying to \[(?P<type>comment|ticket):(?P<id>\d+)\s+(?P<username>[^]]+)\]:')
     def reply_replace(m):
         """
         Replying to [comment:4 glen]:
+        Replying to [ticket:41 katlyn]:
         """
 
         d = m.groupdict()
-        # fallback to original id, can be fixed manually after import
-        pprint(['WIKI_NOTE_MAP for %s' % d['comment_id'], note_map])
-        comment_id = int(d['comment_id'])
-        note_id = note_map.get(comment_id, comment_id)
-        d['link'] = '#note_%s' % note_id
+        link_id = int(d['id'])
+        if d['type'] == 'comment':
+            # fallback to original id, can be fixed manually after import
+            note_id = note_map.get(link_id, link_id)
+            d['link'] = '#note_%d' % note_id
+            return "Replying to [%(username)s](%(link)s):" % d
+        elif d['type'] == 'ticket':
+            d['link'] = '#%d' % link_id
+        else:
+            raise Exception("Unsupported type: %s" % d['type'])
 
         return "Replying to [%(username)s](%(link)s):" % d
 

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -141,15 +141,17 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
         return "Replying to [%(username)s](%(link)s):" % d
 
     commit_re = re.compile(r"""
-        \[(?P<revision>\d+)\] | # revision in brackets
-        r(?P<revision2>\d+) |   # revision with r-prefix
-        \[(?P<rev1>\d+)-(?P<rev2>\d+)\] # revision range
+        \[(?P<revision>\d+)\] # revision in brackets
+        | r(?P<revision2>\d+) # revision with r-prefix
+        | \[(?P<rev1>\d+)-(?P<rev2>\d+)\] # revision range
+        | changeset:(?P<changeset>\d+)
     """, re.X)
     def commit_replace(m):
         """
         (In [35214])
         [36859], [36860]
         Changesets [36872-36874]
+        changeset:38934
         """
         d = m.groupdict()
         d[0] = str(m.group(0))
@@ -159,7 +161,10 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
 
             return "[%(rev1)s..%(rev2)s](../compare/%(rev1)s...%(rev2)s)" % d
         else:
-            revision = str(d.get('revision', d.get('revision2')))
+            if d['changeset']:
+                revision = str(d.get('changeset'))
+            else:
+                revision = str(d.get('revision', d.get('revision2')))
             d['git_hash'] = svn2git_revisions.get(revision, d[0])
 
             return "%(git_hash)s" % d

--- a/src/tracboat/users.py
+++ b/src/tracboat/users.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+import logging
+import six
+import random
+import string
+from itertools import chain
+from pprint import pprint
+
+class UserManager():
+    def __init__(self, gitlab, usermap={}, userattrs={}, fallback_user=None, create_users=False):
+        self.gitlab = gitlab
+        self.logger = logging.getLogger(__name__)
+        self.usermap = usermap
+        self.userattrs = userattrs
+        self.fallback_user = fallback_user
+        self.create_users = create_users
+
+        # GitLab User Model objects
+        self.users = {}
+
+    def get_email(self, login):
+        self.logger.debug("get_email:%s" % login)
+        return self.users[login].email
+
+    # trac_user_handle -> gitlab_user_handle
+    def get_login(self, login, fallback=None):
+        self.logger.debug("get_login:%s" % login)
+#        try:
+        return self.users[login].username
+#        except KeyError:
+#            return fallback
+
+    def load_users(self, users):
+        """
+        Load Trac users into internal cache
+        """
+
+        for login in users:
+            email = self.usermap.get(login, self.fallback_user)
+            self.create_user(email)
+            user = self.gitlab.get_user(email)
+            self.logger.info("Load %s as %s: %r" % (login, email, user))
+            self.users[login] = user
+
+    def create_user(self, email):
+        if self.gitlab.user_exists(email):
+            return
+
+        if not self.create_users:
+            raise Exception, 'User creation disabled, no account for %r' % email
+
+        # set mandatory values to defaults
+        attrs = {
+            'email': email,
+            'username': email.split('@')[0],
+            'encrypted_password': self.generate_password(),
+            'two_factor_enabled' : False,
+        }
+
+        attrs.update(userattrs.get(email, {}))
+        self.gitlab.create_user(**attrs)
+        self.logger.info('Created GitLab user %r', email)
+        self.logger.debug('Created GitLab user %r with attributes: %r', email, attrs)
+
+    def generate_password(self, length=None):
+        alphabet = string.ascii_letters + string.digits + string.punctuation
+        return ''.join(random.choice(alphabet) for _ in range(length or 30))

--- a/svnrevisions.py
+++ b/svnrevisions.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python2
+
+import shelve
+import sys
+
+filename, revision, commit = sys.argv[1:4]
+db = shelve.open(filename)
+
+print "ADD[%s]: %s -> %s" % (filename, revision, commit)
+db[revision] = commit
+print "added as %s" % db[revision]
+
+db.close()

--- a/tracboat.sh
+++ b/tracboat.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -xe
+
+sudo -H -u git `which tracboat` "$@"

--- a/tracboat.sh
+++ b/tracboat.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -xe
 
-sudo -H -u git `which tracboat` "$@"
+. VENV/bin/activate
+tracboat=$(which tracboat)
+
+sudo -H -u git "$tracboat" "$@"

--- a/tracboat.sh
+++ b/tracboat.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -xe
+set -e
 
 . VENV/bin/activate
 tracboat=$(which tracboat)

--- a/users.sh
+++ b/users.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -xe
+
+./env.sh
+
+exec ./tracboat.sh -vv --config-file="$@" users


### PR DESCRIPTION
publishing my local changes that i used to import my projects from trac -> gitlab.

splitting the changes per feature pull requests is too much efforts, so here they come all in one PR, cleaned up from very specific local changes.

TODO:
- document `svn2git_revisions`
- document `model-generate.sh`
- drop older models as `IssueAssignees`, etc tables require certain version
- `migrate_wiki` is disabled (as i didn't need it), enable if it still works
- `clear_issues`, `clear_labels` should be configurable