### PR TITLE
Allow attachment to be referenced multiple times

### DIFF
--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -303,7 +303,14 @@ class Connection(ConnectionBase):
     def save_wiki_attachment(self, path, binary):
         filename = os.path.join(self.uploads_path, self.project_qualname, path)
         if os.path.isfile(filename):
-            raise Exception("file already exists: %r" % filename)
+            with open(filename, "rb") as bin_f:
+                file_content = bin_f.read()
+                bin_f.close()
+
+                if binary == file_content:
+                    return
+
+                raise Exception("file already exists: %r" % filename)
         directory = os.path.dirname(filename)
         if not os.path.exists(directory):
             os.makedirs(directory)


### PR DESCRIPTION
In my wiki multiple pages link to the same attachments (mostly images) and I got an error during import.
This is my workaround, maybe you'll think of a more elegant solution ?