### PR TITLE
users.py: Use Python 3-compatible syntax

### DIFF
--- a/src/tracboat/users.py
+++ b/src/tracboat/users.py
@@ -48,7 +48,7 @@ class UserManager():
             return
 
         if not self.create_users:
-            raise Exception, 'User creation disabled, no account for %r' % email
+            raise Exception('User creation disabled, no account for %r' % email)
 
         # set mandatory values to defaults
         attrs = {


### PR DESCRIPTION
The previous form generates a syntax error on Python 3.