### PR TITLE
Fix broken `psycopg2` dependency by bumping version.

### DIFF
--- a/requirements/develop.txt
+++ b/requirements/develop.txt
@@ -23,7 +23,7 @@ pbr==2.1.0                # via mock
 peewee==2.9.2
 pip-tools==1.9.0
 pluggy==0.4.0             # via tox
-psycopg2==2.7.1
+psycopg2==2.7.6.1
 py==1.4.33                # via pytest, pytest-catchlog, tox
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.5.0           # via flake8

--- a/requirements/dist.txt
+++ b/requirements/dist.txt
@@ -6,7 +6,7 @@
 #
 click==6.7
 peewee==2.9.2
-psycopg2==2.7.1
+psycopg2==2.7.6.1
 pymongo==3.4.0
 six==1.10.0
 toml==0.9.2


### PR DESCRIPTION
The current version (2.7.1) of the `psycopg2` module was giving the following error when imported:

```text
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ben/code/tracboat/VENV/local/lib/python2.7/site-packages/psycopg2/__init__.py", line 50, in <module>
    from psycopg2._psycopg import (                     # noqa
ImportError: /home/ben/code/tracboat/VENV/local/lib/python2.7/site-packages/psycopg2/.libs/libresolv-2-c4c53def.5.so: symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference
```

After bumping the version, the newest `psycopg2` release (2.7.6.1) still gives a warning but works:

```text
/home/ben/code/tracboat/VENV/local/lib/python2.7/site-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)
```

List of all `psycopg2` releases here: https://github.com/psycopg/psycopg2/releases