### PR TITLE
isolate milestones clear from clear issues method

### DIFF
--- a/src/tracboat/gitlab/__init__.py
+++ b/src/tracboat/gitlab/__init__.py
@@ -66,6 +66,14 @@ class ConnectionBase(object):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def clear_labels(self):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def clear_milestones(self):
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def get_milestone(self, milestone_name):
         raise NotImplementedError()
 

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -134,6 +134,12 @@ class Connection(ConnectionBase):
             # set their colour every time when you re-run the migration.
             label.delete_instance()
 
+    def clear_milestones(self):
+        M = self.model
+
+        M.Milestones.delete().where(
+            M.Milestones.project == self.project_id).execute()
+
     def clear_issues(self):
         M = self.model
         # Delete issues and everything that goes with them...
@@ -157,10 +163,6 @@ class Connection(ConnectionBase):
         for directory in glob.glob(os.path.join(self.uploads_path, self.project_qualname, 'issue_*')):
             LOG.info("rm -rf %r" % directory)
             shutil.rmtree(directory, ignore_errors=True)
-
-        # XXX: method is called "Clear issues" but clears milestones?!?!
-        M.Milestones.delete().where(
-            M.Milestones.project == self.project_id).execute()
 
     def get_milestone(self, milestone_name):
         M = self.model

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -381,14 +381,7 @@ def migrate_milestones(trac_milestones, gitlab):
         milestone_args = milestone_kwargs(milestone)
         LOG.info('migrate milestone %r', milestone_args)
         gitlab_milestone_id = gitlab.create_milestone(**milestone_args)
-        # => #<Milestone id: 2456,
-#        title: "v1", project_id: 166, description: "", 
-#due_date: nil, created_at: "2017-04-21 22:45:30", 
-#updated_at: "2017-04-21 22:45:30", state: "active", 
-#iid: 1, title_html: "v1", description_html: "", 
-#start_date: nil>
         LOG.info('migrated milestone %s -> %s', title, gitlab_milestone_id)
-
 
 def migrate_wiki(trac_wiki, gitlab, output_dir):
     for title, wiki in six.iteritems(trac_wiki):
@@ -444,9 +437,9 @@ def migrate(trac, gitlab_project_name, gitlab_version, gitlab_db_connector,
 
     # XXX
     # if overwite and mode == direct
-    # XXX: this clears also milestones
     # XXX: make configurable
     gitlab.clear_issues()
+    gitlab.clear_milestones()
 #    gitlab.clear_labels()
 
     # 1. Wiki


### PR DESCRIPTION
moves `clear_milestones` out of `clear_issues` method to allow skipping clearing milestones. no config support, just code edit.