### PR TITLE
Don't just quit when retrieving an attachment fails

### DIFF
--- a/src/tracboat/trac.py
+++ b/src/tracboat/trac.py
@@ -54,6 +54,16 @@ def ticket_get_changelog(source, ticket_id):
 
 
 def ticket_get_attachments(source, ticket_id):
+
+    def _get_attachment(source, ticket_id, filename):
+        LOG.debug("Retriving attachment '{}' on ticket {}".format(filename, ticket_id))
+        try:
+            return source.ticket.getAttachment(ticket_id, filename).data
+        except Exception as ex:
+            error = "Could not retrive attachment '{}' on ticket {}, error: {}".format(filename, ticket_id, ex)
+            LOG.error(error)
+            return error
+    
     LOG.debug('ticket_get_attachments of ticket #%s', ticket_id)
     return {
         meta[0]: {
@@ -64,7 +74,7 @@ def ticket_get_attachments(source, ticket_id):
                 'time': meta[3],
                 'author': meta[4],
             },
-            'data': _safe_retrieve_data(source.ticket.getAttachment(ticket_id, meta[0]).data)
+            'data': _safe_retrieve_data(_get_attachment(source, ticket_id, meta[0]))
         }
         for meta in source.ticket.listAttachments(ticket_id)
     }


### PR DESCRIPTION
I am trying to figure out if I can use Tracboat to migrate [this Trac instance of zfec](https://tahoe-lafs.org/trac/zfec/) to GitLab.  One of the first problems I came across was that Tracboat doesn't like when retrieving some attachments results in a 404, such as in the case of [this trac ticket](https://tahoe-lafs.org/trac/zfec/attachment/ticket/3/).  This has already been reported in #69.

With the workaround in this PR, Tracboat doesn't just quit when it encounters a 404 when retrieving an attachment.  I am not sure this is the right approach though.