### PR TITLE
Various fixes for user creation, markdown conversion, and cc handling

### DIFF
--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -54,6 +54,8 @@ USER_DEFAULTS = {
     'twitter': '',
     'website_url': '',
     'projects_limit': 0,
+    'state': 'active',
+    'created_at': datetime.now(),
 }
 
 

--- a/src/tracboat/gitlab/direct.py
+++ b/src/tracboat/gitlab/direct.py
@@ -34,6 +34,8 @@ NAMESPACE_DEFAULTS = {
     'description': 'imported',
     'request_access_enabled': True,
     'visibility_level': 0,
+    'created_at': datetime.now(),
+    'updated_at': datetime.now(),
 }
 
 
@@ -206,6 +208,13 @@ class Connection(ConnectionBase):
     #         M.Issues.project == self.project_id).aggregate(
     #             peewee.fn.Count(M.Issues.id)) + 1
 
+    def create_namespace(self, name, path, user_id):
+        M = self.model
+        try:
+            M.Namespaces.get(M.Namespaces.name == name)
+        except M.Namespaces.DoesNotExist:
+            M.Namespaces.create(name=name, path=path, owner=user_id, **NAMESPACE_DEFAULTS)
+
     def create_user(self, email, **kwargs):
         M = self.model
         try:
@@ -218,6 +227,7 @@ class Connection(ConnectionBase):
             user = M.Users.create(**parms)
             user.save()
             LOG.debug("user %r created", email)
+            self.create_namespace(user.username, user.username, user.id)
         return user.id
 
     def create_milestone(self, **kwargs):

--- a/src/tracboat/migrate.py
+++ b/src/tracboat/migrate.py
@@ -155,12 +155,21 @@ def format_change_note(change, issue_id=None, note_map={}, svn2git_revisions={},
         # /var/opt/gitlab/gitlab-rails/uploads/glen/photoproject/f38feb8a3dc4c5bcabdc41ccc5894ac3
         note = '- **Attachment** [%s](%s/%s) added' % (change['newvalue'], attachments_path, change['newvalue'])
     elif field == 'cc':
-        if change['newvalue'] == '':
+        note = ''
+        for value in change['newvalue'].split(','):
+            value = value.strip()
+            if value == '':
+                continue
+
+            user = usermanager.get_login(value, value)
+            if not note:
+                note = '- **Cc** added @%s' % user
+            else:
+                note += ', @%s' % user
+        
+        if not note:
             LOG.error('Unexpected empty value for %s' % field)
             return ''
-
-        user = usermanager.get_login(change['newvalue'], change['newvalue'])
-        note = '- **Cc** added @%s' % user
     elif field == 'owner':
         if change['oldvalue'] == '' and change['newvalue'] == '':
             # XXX no idea why such changes even exist

--- a/src/tracboat/trac.py
+++ b/src/tracboat/trac.py
@@ -26,7 +26,8 @@ def _authors_collect(wiki=None, tickets=None):
         [ticket['attributes']['reporter'] for ticket in six.itervalues(tickets)] +
         [ticket['attributes']['owner'] for ticket in six.itervalues(tickets)] +
         [change['author'] for ticket in six.itervalues(tickets) for change in ticket['changelog']] +
-        [change['newvalue'] for ticket in six.itervalues(tickets) for change in ticket['changelog'] if change['field'] in ['cc', 'owner']]
+        [change['newvalue'] for ticket in six.itervalues(tickets) for change in ticket['changelog'] if change['field'] == 'owner'] +
+        [value.strip() for ticket in six.itervalues(tickets) for change in ticket['changelog'] if change['field'] == 'cc' for value in change['newvalue'].split(',')]
     ))
 
 

--- a/src/tracboat/trac2down.py
+++ b/src/tracboat/trac2down.py
@@ -216,8 +216,8 @@ def convert(text, base_path, multilines=True, note_map={}, attachments_path=None
         # not blockquote?
         if not line.startswith('    '):
             line = re.sub(r'\[(https?://[^\s\[\]]+)\s([^\[\]]+)\]', r'[\2](\1)', line)
-            line = re.sub(r'\[(?<!!|wiki:)([^\]]+)]', r'[\1](\1)', line) # [WikiName] format
-            line = re.sub(r'\[(?<!!|wiki:)([^ \]]+) ([^\]]+)\]', r'[\2](\1)', line) # [WikiName Friendly name] format
+            line = re.sub(r'\[(?<!!|wiki:)([A-Z][a-z]+[a-z0-9]*[A-Z][^\ \]]*)\]', r'[\1](\1)', line) # [WikiName] format
+            line = re.sub(r'\[(?<!!|wiki:)([A-Z][a-z]+[a-z0-9]*[A-Z][^ \]]+) ([^\]]+)\]', r'[\2](\1)', line) # [WikiName Friendly name] format
             line = re.sub(r'\[wiki:([^\s\[\]]+)\s([^\[\]]+)\]', r'[\2](%s/\1)' % os.path.relpath('/wikis/', base_path), line)
             line = re.sub(r'\[wiki:([^\s\[\]]+)\]', r'[\1](\1)', line)
             line = re.sub(r'\!(([A-Z][a-z0-9]+){2,})', r'\1', line)


### PR DESCRIPTION
This PR includes:
- Added more default required user fields.
- Fixed some false positives with the bracketed wiki link syntax with no wiki: prefix. Ensure a pascal case name is present.
- Add handling for comma separated cc values.
- Be sure to create namespaces for new users.

I'm hopeful this is the last PR I'll have to make based on our migration. To give you a little background we're actually using this to migrate trac to gitlab then gitlab to github because github has a tool that provides better importing from gitlab. We were previously on gitlab and never switched issues to gitlab. We experimented with tracboat, but never actually migrated because of internal issues. The first PR was just what was needed for exporting and then when I used the github importer tool I noticed a few other tweaks that needed to be made.